### PR TITLE
Support applications that use a custom username field

### DIFF
--- a/mfa/fido2.py
+++ b/mfa/fido2.py
@@ -35,7 +35,7 @@ def register_begin(user):
     registration_data, state = fido2.register_begin(
         {
             'id': str(user.id).encode('utf-8'),
-            'name': user.username,
+            'name': user.get_username(),
             'displayName': user.get_full_name(),
         },
         get_credentials(user),

--- a/mfa/totp.py
+++ b/mfa/totp.py
@@ -8,7 +8,7 @@ def register_begin(user):
     secret = pyotp.random_base32()
     totp = pyotp.TOTP(secret)
     url = totp.provisioning_uri(
-        user.username,
+        user.get_username(),
         issuer_name=settings.MFA_SITE_TITLE,
     )
     return {'url': url, 'secret': secret}, secret

--- a/mfa/views.py
+++ b/mfa/views.py
@@ -119,7 +119,7 @@ class MFAAuthView(StrongholdPublicMixin, MFAFormView):
         user_login_failed.send(
             sender=__name__,
             credentials={
-                'username': self.user.username,
+                'username': self.user.get_username(),
                 'code': form.cleaned_data.get('code'),
             },
             request=self.request,


### PR DESCRIPTION
Use Django's indirection for getting the username.

This respects applications that have set User.USERNAME_FIELD to something else.

---

I'm experimenting with this lib in an app that uses a different field for the username, and I think this should make that work. I haven't tested this in detail locally yet, as I'm still sorting out some of the plumbing, but I'm reasonably confident this will behave as expected.