### PR TITLE
send email on failed login

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ Optionally, you can add `'mfa.middleware.MFAEnforceMiddleware'` to `MIDDLEWARE`
 requests to `'mfa:list'` as long as the user has no MFAKeys. You can use
 `mfa.decorators.public` to add exceptions.
 
+## Send email on failed login attempt
+
+If someone failes to login on the second factor that might indicate that the
+first factor (password) has been compromised. django-mfa3 will automatically
+send a warning to affected users under the following conditions:
+
+-   Django needs to be [configured for sending email](https://docs.djangoproject.com/en/4.1/topics/email/)
+-   There must be an email address associated with the user account
+-   You need to provide some templates
+    -   `mfa/login_failed_subject.txt`: optional, a default is included
+    -   `mfa/login_failed_email.txt`: required, an example is included in the
+        [tests](/tests/templates/mfa/login_failed_email.txt)
+    -   `mfa/login_failed_email.html`: optional
+
+All templates have access to the following context data: `email`, `domain`,
+`site_name`, `user`, `method`.
+
 ## Status
 
 I am not sure whether I will be able to maintain this library long-term. If you

--- a/mfa/mail.py
+++ b/mfa/mail.py
@@ -1,0 +1,41 @@
+from django.core.mail import EmailMultiAlternatives
+from django.template import TemplateDoesNotExist
+from django.template import loader
+
+from . import settings
+
+SUBJECT_TEMPLATE = 'mfa/login_failed_subject.txt'
+BODY_TEMPLATE = 'mfa/login_failed_email.txt'
+HTML_TEMPLATE = 'mfa/login_failed_email.html'
+
+
+def send_mail(user, method):
+    email_field_name = user.get_email_field_name()
+    user_email = getattr(user, email_field_name)
+    if not user_email:
+        return 0
+
+    context = {
+        'email': user_email,
+        'domain': settings.DOMAIN,
+        'site_name': settings.SITE_TITLE,
+        'user': user,
+        'method': method.name,
+    }
+
+    try:
+        subject = loader.render_to_string(SUBJECT_TEMPLATE, context)
+        subject = ' '.join(subject.splitlines()).strip()
+        body = loader.render_to_string(BODY_TEMPLATE, context)
+    except TemplateDoesNotExist:
+        return 0
+
+    message = EmailMultiAlternatives(subject, body, to=[user_email])
+
+    try:
+        html_body = loader.render_to_string(HTML_TEMPLATE, context)
+        message.attach_alternative(html_body, 'text/html')
+    except TemplateDoesNotExist:
+        pass
+
+    return message.send()

--- a/mfa/templates/mfa/login_failed_subject.txt
+++ b/mfa/templates/mfa/login_failed_subject.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% autoescape off %}
+{% blocktranslate %}Failed login on {{ site_name }}{% endblocktranslate %}
+{% endautoescape %}

--- a/mfa/templates/mfa/login_failed_subject.txt
+++ b/mfa/templates/mfa/login_failed_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% blocktranslate %}Failed login on {{ site_name }}{% endblocktranslate %}
+{% blocktranslate %}Attempted login to {{ site_name }} using a wrong two-factor authentication code{% endblocktranslate %}
 {% endautoescape %}

--- a/mfa/views.py
+++ b/mfa/views.py
@@ -16,6 +16,7 @@ from django.views.generic import ListView
 from . import settings
 from .forms import MFAAuthForm
 from .forms import MFACreateForm
+from .mail import send_mail
 from .mixins import MFAFormView
 from .models import MFAKey
 
@@ -125,6 +126,7 @@ class MFAAuthView(StrongholdPublicMixin, MFAFormView):
             credentials={'username': self.user.get_username()},
             request=self.request,
         )
+        send_mail(self.user, self.method)
         return super().form_invalid(form)
 
     def form_valid(self, form):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -39,7 +41,7 @@ INSTALLED_APPS = [
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [Path(__file__).parent / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/tests/templates/mfa/login_failed_email.txt
+++ b/tests/templates/mfa/login_failed_email.txt
@@ -1,0 +1,6 @@
+Dear {{ user.username }},
+
+someone tried to log in to your account at {{ site_name }} ({{ domain }}).
+They managed to enter the correct password, but failed at {{ method }}.
+
+If this wasn't you we strongly recommend to change your password.

--- a/tests/templates/mfa/login_failed_email.txt
+++ b/tests/templates/mfa/login_failed_email.txt
@@ -1,6 +1,10 @@
 Dear {{ user.username }},
 
-someone tried to log in to your account at {{ site_name }} ({{ domain }}).
-They managed to enter the correct password, but failed at {{ method }}.
+We detected an attempt to log in to your account on {{ site_name }}
+({{ domain }}) using a wrong two-factor authentication code. This means someone
+managed to enter the correct password, but failed at {{ method }}.
 
-If this wasn't you we strongly recommend to change your password.
+If this was you and you entered a wrong two-factor authentication code by
+accident, you may ignore this email.
+
+If this was not you, we strongly recommend to change your password.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,3 +1,5 @@
+from django.core import mail
+
 import pyotp
 from django.test import TestCase
 from django.contrib.auth.hashers import make_password
@@ -6,6 +8,7 @@ from django.contrib.auth.models import User
 from mfa.methods import fido2
 from mfa.models import MFAKey
 from mfa.templatetags.mfa import get_qrcode
+from mfa.mail import send_mail
 
 
 class MFATestCase(TestCase):
@@ -292,3 +295,25 @@ class QRCodeTest(TestCase):
         code = get_qrcode('some_data')
         self.assertTrue(code.startswith('<svg'))
         self.assertTrue(code.endswith('</svg>'))
+
+
+class MailTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            'test', password='password', email='test@example.com'
+        )
+
+    def test_send_mail(self):
+        count = send_mail(self.user, fido2)
+        self.assertEqual(count, 1)
+
+        message = mail.outbox[0]
+        self.assertEqual(message.to, ['test@example.com'])
+        self.assertEqual(message.subject, 'Failed login on Tests')
+        self.assertEqual(message.body, """Dear test,
+
+someone tried to log in to your account at Tests (localhost).
+They managed to enter the correct password, but failed at FIDO2.
+
+If this wasn't you we strongly recommend to change your password.
+""")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -309,11 +309,15 @@ class MailTest(TestCase):
 
         message = mail.outbox[0]
         self.assertEqual(message.to, ['test@example.com'])
-        self.assertEqual(message.subject, 'Failed login on Tests')
+        self.assertEqual(message.subject, 'Attempted login to Tests using a wrong two-factor authentication code')  # noqa
         self.assertEqual(message.body, """Dear test,
 
-someone tried to log in to your account at Tests (localhost).
-They managed to enter the correct password, but failed at FIDO2.
+We detected an attempt to log in to your account on Tests
+(localhost) using a wrong two-factor authentication code. This means someone
+managed to enter the correct password, but failed at FIDO2.
 
-If this wasn't you we strongly recommend to change your password.
+If this was you and you entered a wrong two-factor authentication code by
+accident, you may ignore this email.
+
+If this was not you, we strongly recommend to change your password.
 """)


### PR DESCRIPTION
this could indicate a case where an attacker has gained access to username and password, but not to the second factor

inspired by:

- https://syslog.ravelin.com/2fa-is-missing-a-key-feature-c781c3861db
- https://docs.djangoproject.com/en/4.1/topics/auth/default/#django.contrib.auth.forms.PasswordResetForm