### PR TITLE
fido2: use JSON encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install django-mfa3
     `settings.py` for a full list of settings.
 4.  Register URLs: `path('mfa/', include('mfa.urls', namespace='mfa')`
 5.  The included templates are just examples, so you should [replace them](https://docs.djangoproject.com/en/stable/howto/overriding-templates/) with your own
-6.  FIDO2 requires client side code. You can either implement it yourself or use the included fido2.js (in which case you will have to provide the third party library [cbor-js](https://www.npmjs.com/package/cbor-js)).
+6.  FIDO2 requires client side code. You can either implement it yourself or use the included fido2.js (in which case you will have to provide the third party library [@github/webauthn-json](https://www.npmjs.com/package/@github/webauthn-json)).
 7.  Somewhere in your app, add a link to `'mfa:list'`
 
 ## Enforce MFA

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install django-mfa3
     `settings.py` for a full list of settings.
 4.  Register URLs: `path('mfa/', include('mfa.urls', namespace='mfa')`
 5.  The included templates are just examples, so you should [replace them](https://docs.djangoproject.com/en/stable/howto/overriding-templates/) with your own
-6.  FIDO2 requires client side code. You can either implement it yourself or use the included fido2.js (in which case you will have to provide the third party library [@github/webauthn-json](https://www.npmjs.com/package/@github/webauthn-json)).
+6.  FIDO2 requires client side code. You can either implement it yourself or use the included fido2.js.
 7.  Somewhere in your app, add a link to `'mfa:list'`
 
 ## Enforce MFA

--- a/mfa/static/mfa/fido2.js
+++ b/mfa/static/mfa/fido2.js
@@ -1,56 +1,54 @@
-(function() {
-    var encode = function(data) {
-        var buffer = CBOR.encode(data);
-        var arr = new Uint8Array(buffer);
-        return arr.reduce((s, b) => s + b.toString(16).padStart(2, '0'), '');
-    };
+var encode = function(data) {
+    var buffer = CBOR.encode(data);
+    var arr = new Uint8Array(buffer);
+    return arr.reduce((s, b) => s + b.toString(16).padStart(2, '0'), '');
+};
 
-    var decode = function(hex) {
-        var arr = new Uint8Array(hex.length / 2);
-        for (var i = 0; i < arr.length; i += 1) {
-            arr[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
-        }
-        return CBOR.decode(arr.buffer);
-    };
+var decode = function(hex) {
+    var arr = new Uint8Array(hex.length / 2);
+    for (var i = 0; i < arr.length; i += 1) {
+        arr[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+    }
+    return CBOR.decode(arr.buffer);
+};
 
-    var initCreate = function() {
-        var form = document.querySelector('form[data-fido2-create]');
-        if (form) {
-            var options = decode(form.dataset.fido2Create);
-            form.addEventListener('submit', function(event) {
-                event.preventDefault();
+var initCreate = function() {
+    var form = document.querySelector('form[data-fido2-create]');
+    if (form) {
+        var options = decode(form.dataset.fido2Create);
+        form.addEventListener('submit', function(event) {
+            event.preventDefault();
 
-                navigator.credentials.create(options).then(attestation => {
-                    this.code.value = encode({
-                        'attestationObject': new Uint8Array(attestation.response.attestationObject),
-                        'clientData': new Uint8Array(attestation.response.clientDataJSON),
-                    });
-                    form.submit();
-                }).catch(alert);
-            });
-        }
-    };
+            navigator.credentials.create(options).then(attestation => {
+                this.code.value = encode({
+                    'attestationObject': new Uint8Array(attestation.response.attestationObject),
+                    'clientData': new Uint8Array(attestation.response.clientDataJSON),
+                });
+                form.submit();
+            }).catch(alert);
+        });
+    }
+};
 
-    var initAuth = function() {
-        var form = document.querySelector('form[data-fido2-auth]');
-        if (form) {
-            var options = decode(form.dataset.fido2Auth);
-            form.addEventListener('submit', function(event) {
-                event.preventDefault();
+var initAuth = function() {
+    var form = document.querySelector('form[data-fido2-auth]');
+    if (form) {
+        var options = decode(form.dataset.fido2Auth);
+        form.addEventListener('submit', function(event) {
+            event.preventDefault();
 
-                navigator.credentials.get(options).then(assertion => {
-                    this.code.value = encode({
-                        'credentialId': new Uint8Array(assertion.rawId),
-                        'authenticatorData': new Uint8Array(assertion.response.authenticatorData),
-                        'clientData': new Uint8Array(assertion.response.clientDataJSON),
-                        'signature': new Uint8Array(assertion.response.signature),
-                    });
-                    form.submit();
-                }).catch(alert);
-            });
-        }
-    };
+            navigator.credentials.get(options).then(assertion => {
+                this.code.value = encode({
+                    'credentialId': new Uint8Array(assertion.rawId),
+                    'authenticatorData': new Uint8Array(assertion.response.authenticatorData),
+                    'clientData': new Uint8Array(assertion.response.clientDataJSON),
+                    'signature': new Uint8Array(assertion.response.signature),
+                });
+                form.submit();
+            }).catch(alert);
+        });
+    }
+};
 
-    initCreate();
-    initAuth();
-})();
+initCreate();
+initAuth();

--- a/mfa/static/mfa/fido2.js
+++ b/mfa/static/mfa/fido2.js
@@ -1,4 +1,4 @@
-import * as webauthnJSON from 'https://cdn.jsdelivr.net/npm/@github/webauthn-json@2.1.1/dist/esm/webauthn-json.browser-ponyfill.js';
+import * as webauthnJSON from './vendor/webauthn-json.browser-ponyfill.js';
 
 var initCreate = function() {
     var form = document.querySelector('form[data-fido2-create]');

--- a/mfa/static/mfa/vendor/webauthn-json.browser-ponyfill.js
+++ b/mfa/static/mfa/vendor/webauthn-json.browser-ponyfill.js
@@ -1,0 +1,243 @@
+/*!
+ * @github/webauthn-json 2.1.1
+ * Copyright (c) 2019 GitHub, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+// src/webauthn-json/base64url.ts
+function base64urlToBuffer(baseurl64String) {
+  const padding = "==".slice(0, (4 - baseurl64String.length % 4) % 4);
+  const base64String = baseurl64String.replace(/-/g, "+").replace(/_/g, "/") + padding;
+  const str = atob(base64String);
+  const buffer = new ArrayBuffer(str.length);
+  const byteView = new Uint8Array(buffer);
+  for (let i = 0; i < str.length; i++) {
+    byteView[i] = str.charCodeAt(i);
+  }
+  return buffer;
+}
+function bufferToBase64url(buffer) {
+  const byteView = new Uint8Array(buffer);
+  let str = "";
+  for (const charCode of byteView) {
+    str += String.fromCharCode(charCode);
+  }
+  const base64String = btoa(str);
+  const base64urlString = base64String.replace(/\+/g, "-").replace(
+    /\//g,
+    "_"
+  ).replace(/=/g, "");
+  return base64urlString;
+}
+
+// src/webauthn-json/convert.ts
+var copyValue = "copy";
+var convertValue = "convert";
+function convert(conversionFn, schema, input) {
+  if (schema === copyValue) {
+    return input;
+  }
+  if (schema === convertValue) {
+    return conversionFn(input);
+  }
+  if (schema instanceof Array) {
+    return input.map((v) => convert(conversionFn, schema[0], v));
+  }
+  if (schema instanceof Object) {
+    const output = {};
+    for (const [key, schemaField] of Object.entries(schema)) {
+      if (schemaField.derive) {
+        const v = schemaField.derive(input);
+        if (v !== void 0) {
+          input[key] = v;
+        }
+      }
+      if (!(key in input)) {
+        if (schemaField.required) {
+          throw new Error(`Missing key: ${key}`);
+        }
+        continue;
+      }
+      if (input[key] == null) {
+        output[key] = null;
+        continue;
+      }
+      output[key] = convert(
+        conversionFn,
+        schemaField.schema,
+        input[key]
+      );
+    }
+    return output;
+  }
+}
+function derived(schema, derive) {
+  return {
+    required: true,
+    schema,
+    derive
+  };
+}
+function required(schema) {
+  return {
+    required: true,
+    schema
+  };
+}
+function optional(schema) {
+  return {
+    required: false,
+    schema
+  };
+}
+
+// src/webauthn-json/basic/schema.ts
+var publicKeyCredentialDescriptorSchema = {
+  type: required(copyValue),
+  id: required(convertValue),
+  transports: optional(copyValue)
+};
+var simplifiedExtensionsSchema = {
+  appid: optional(copyValue),
+  appidExclude: optional(copyValue),
+  credProps: optional(copyValue)
+};
+var simplifiedClientExtensionResultsSchema = {
+  appid: optional(copyValue),
+  appidExclude: optional(copyValue),
+  credProps: optional(copyValue)
+};
+var credentialCreationOptions = {
+  publicKey: required({
+    rp: required(copyValue),
+    user: required({
+      id: required(convertValue),
+      name: required(copyValue),
+      displayName: required(copyValue)
+    }),
+    challenge: required(convertValue),
+    pubKeyCredParams: required(copyValue),
+    timeout: optional(copyValue),
+    excludeCredentials: optional([publicKeyCredentialDescriptorSchema]),
+    authenticatorSelection: optional(copyValue),
+    attestation: optional(copyValue),
+    extensions: optional(simplifiedExtensionsSchema)
+  }),
+  signal: optional(copyValue)
+};
+var publicKeyCredentialWithAttestation = {
+  type: required(copyValue),
+  id: required(copyValue),
+  rawId: required(convertValue),
+  authenticatorAttachment: optional(copyValue),
+  response: required({
+    clientDataJSON: required(convertValue),
+    attestationObject: required(convertValue),
+    transports: derived(
+      copyValue,
+      (response) => {
+        var _a;
+        return ((_a = response.getTransports) == null ? void 0 : _a.call(response)) || [];
+      }
+    )
+  }),
+  clientExtensionResults: derived(
+    simplifiedClientExtensionResultsSchema,
+    (pkc) => pkc.getClientExtensionResults()
+  )
+};
+var credentialRequestOptions = {
+  mediation: optional(copyValue),
+  publicKey: required({
+    challenge: required(convertValue),
+    timeout: optional(copyValue),
+    rpId: optional(copyValue),
+    allowCredentials: optional([publicKeyCredentialDescriptorSchema]),
+    userVerification: optional(copyValue),
+    extensions: optional(simplifiedExtensionsSchema)
+  }),
+  signal: optional(copyValue)
+};
+var publicKeyCredentialWithAssertion = {
+  type: required(copyValue),
+  id: required(copyValue),
+  rawId: required(convertValue),
+  authenticatorAttachment: optional(copyValue),
+  response: required({
+    clientDataJSON: required(convertValue),
+    authenticatorData: required(convertValue),
+    signature: required(convertValue),
+    userHandle: required(convertValue)
+  }),
+  clientExtensionResults: derived(
+    simplifiedClientExtensionResultsSchema,
+    (pkc) => pkc.getClientExtensionResults()
+  )
+};
+
+// src/webauthn-json/basic/api.ts
+function createRequestFromJSON(requestJSON) {
+  return convert(base64urlToBuffer, credentialCreationOptions, requestJSON);
+}
+function createResponseToJSON(credential) {
+  return convert(
+    bufferToBase64url,
+    publicKeyCredentialWithAttestation,
+    credential
+  );
+}
+function getRequestFromJSON(requestJSON) {
+  return convert(base64urlToBuffer, credentialRequestOptions, requestJSON);
+}
+function getResponseToJSON(credential) {
+  return convert(
+    bufferToBase64url,
+    publicKeyCredentialWithAssertion,
+    credential
+  );
+}
+
+// src/webauthn-json/basic/supported.ts
+function supported() {
+  return !!(navigator.credentials && navigator.credentials.create && navigator.credentials.get && window.PublicKeyCredential);
+}
+
+// src/webauthn-json/browser-ponyfill.ts
+async function create(options) {
+  const response = await navigator.credentials.create(
+    options
+  );
+  response.toJSON = () => createResponseToJSON(response);
+  return response;
+}
+async function get(options) {
+  const response = await navigator.credentials.get(
+    options
+  );
+  response.toJSON = () => getResponseToJSON(response);
+  return response;
+}
+export {
+  create,
+  get,
+  createRequestFromJSON as parseCreationOptionsFromJSON,
+  getRequestFromJSON as parseRequestOptionsFromJSON,
+  supported
+};

--- a/mfa/templates/mfa/auth_FIDO2.html
+++ b/mfa/templates/mfa/auth_FIDO2.html
@@ -15,4 +15,4 @@
 </form>
 
 <script src="{% static 'cbor-js/cbor.js' %}"></script>
-<script src="{% static 'mfa/fido2.js' %}"></script>
+<script src="{% static 'mfa/fido2.js' %}" type="module"></script>

--- a/mfa/templates/mfa/auth_FIDO2.html
+++ b/mfa/templates/mfa/auth_FIDO2.html
@@ -14,5 +14,4 @@
     <a href="{% url 'mfa:auth' 'recovery' %}">Use recovery code instead</a>
 </form>
 
-<script src="{% static 'cbor-js/cbor.js' %}"></script>
 <script src="{% static 'mfa/fido2.js' %}" type="module"></script>

--- a/mfa/templates/mfa/create_FIDO2.html
+++ b/mfa/templates/mfa/create_FIDO2.html
@@ -16,4 +16,4 @@
 </form>
 
 <script src="{% static 'cbor-js/cbor.js' %}"></script>
-<script src="{% static 'mfa/fido2.js' %}"></script>
+<script src="{% static 'mfa/fido2.js' %}" type="module"></script>

--- a/mfa/templates/mfa/create_FIDO2.html
+++ b/mfa/templates/mfa/create_FIDO2.html
@@ -15,5 +15,4 @@
     <button>Create</button>
 </form>
 
-<script src="{% static 'cbor-js/cbor.js' %}"></script>
 <script src="{% static 'mfa/fido2.js' %}" type="module"></script>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -187,12 +187,6 @@ class FIDO2Test(MFATestCase):
         res = self.client.get('/mfa/create/FIDO2/')
         self.assertEqual(res.status_code, 200)
 
-    def test_encode(self):
-        self.assertEqual(fido2.encode({'foo': [1, 2]}), 'a163666f6f820102')
-
-    def test_decode(self):
-        self.assertEqual(fido2.decode('a163666f6f820102'), {'foo': [1, 2]})
-
     def test_origin_https(self):
         for domain, value, expected in [
             ('example.com', 'https://example.com', True),


### PR DESCRIPTION
JSON serialization was recently [added to the webauthn editors draft](https://github.com/w3c/webauthn/issues/1683). python-fido2 added support in 1.1.0.

This would provide better (standardized) solutions for #1 and #10. However, currently this would still require a polyfill. Therefor this would be a breaking change.

I think I will hold this off until this is available in browsers or at least until this has gained significant traction.