### PR TITLE
Fix templates

### DIFF
--- a/mfa/forms.py
+++ b/mfa/forms.py
@@ -28,4 +28,4 @@ class MFAAuthForm(MFABaseForm):
 
 
 class MFACreateForm(MFABaseForm):
-    name = forms.CharField(label=_('Name'), max_length=32)
+    name = forms.CharField(label=_('Authentication name'), max_length=32)

--- a/mfa/middleware.py
+++ b/mfa/middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import redirect
 from django.utils.deprecation import MiddlewareMixin
 
@@ -6,6 +7,7 @@ class MFAEnforceMiddleware(MiddlewareMixin):
     def process_view(self, request, view_func, view_args, view_kwargs):
         if (
             not getattr(view_func, 'mfa_public', False)
+            and not request.path.startswith(settings.STATIC_URL)
             and request.user.is_authenticated
             and not request.user.mfakey_set.exists()
         ):

--- a/mfa/templates/mfa/auth_FIDO2.html
+++ b/mfa/templates/mfa/auth_FIDO2.html
@@ -1,18 +1,33 @@
-{% load static %}
+{% extends "mfa/base.html" %}
+{% load i18n static %}
 
+{% block content_title %}
 <h1>Two-factor authentication</h1>
-<p>When you are ready to authenticate with FIDO2, press the button below.</p>
+{% endblock %}
+
+{% block content_subtitle %}
+<p>
+    When you are ready to authenticate with FIDO2,
+    press the button below
+    {% for method in methods %}
+    {% if method != 'FIDO2' %}
+    or <a href="{% url 'mfa:auth' method %}">use {{method}} instead</a>
+    {% endif %}
+    {% endfor %}.
+</p>
+{% endblock %}
+
+{% block form %}
+{% load static %}
+<script src="{% static 'cbor-js/cbor.js' %}"></script>
+<script src="{% static 'mfa/fido2.js' %}"></script>
 
 <form data-fido2-auth="{{ mfa_data }}" method="POST">
     {% csrf_token %}
-    {% for error in form.errors %}
-        <p>{{ error }}</p>
-    {% endfor %}
     {{ form.code.as_hidden }}
-    <button autofocus>Verify</button>
-    <a href="{% url 'mfa:auth' 'TOTP' %}">Use TOTP instead</a>
-    <a href="{% url 'mfa:auth' 'recovery' %}">Use recovery code instead</a>
+    <div class="submit-row">
+        <input type="submit" value="{% translate 'Verify' %}" autofocus>
+        <input type="hidden" name="next" value="{{ next }}">
+    </div>
 </form>
-
-<script src="{% static 'cbor-js/cbor.js' %}"></script>
-<script src="{% static 'mfa/fido2.js' %}"></script>
+{% endblock %}

--- a/mfa/templates/mfa/auth_TOTP.html
+++ b/mfa/templates/mfa/auth_TOTP.html
@@ -1,16 +1,32 @@
-<h1>Two-factor authentication</h1>
-<p>Open your TOTP app to get an authentication code.</p>
+{% extends "mfa/base.html" %}
+{% load i18n static %}
 
+{% block content_title %}
+<h1>Two-factor authentication</h1>
+{% endblock %}
+
+{% block content_subtitle %}
+<p>
+    Open your TOTP app to get an authentication code
+    {% for method in methods %}
+    {% if method != 'TOTP' %}
+    or <a href="{% url 'mfa:auth' method %}">use {{method}} instead</a>
+    {% endif %}
+    {% endfor %}.
+</p>
+{% endblock %}
+
+{% block form %}
 <form method="POST">
     {% csrf_token %}
-    {% for error in form.non_field_errors %}
-        <p>{{ error }}</p>
-    {% endfor %}
-    <label>
-        {{ form.code.label }}
-        {{ form.code }}
-    </label>
-    <button>Verify</button>
-    <a href="{% url 'mfa:auth' 'FIDO2' %}">Use FIDO2 instead</a>
-    <a href="{% url 'mfa:auth' 'recovery' %}">Use recovery code instead</a>
+    <div class="form-row">
+        {{ form.code.errors }}
+        <h2>{{ form.code.label }}:</h2>
+        <p>{{ form.code }}</p>
+    </div>
+    <div class="submit-row">
+        <input type="submit" value="{% translate 'Verify' %}">
+        <input type="hidden" name="next" value="{{ next }}">
+    </div>
 </form>
+{% endblock %}

--- a/mfa/templates/mfa/auth_recovery.html
+++ b/mfa/templates/mfa/auth_recovery.html
@@ -1,21 +1,34 @@
-<h1>Two-factor authentication</h1>
+{% extends "mfa/base.html" %}
+{% load i18n static %}
 
+{% block content_title %}
+<h1>Two-factor authentication</h1>
+{% endblock %}
+
+{% block content_subtitle %}
 <p>
     <strong>WARNING</strong>:
     The recovery code will be removed after it has been used.
     Make sure to create a new one after login!
+    {% for method in methods %}
+    {% if method != 'recovery' %}
+    or <a href="{% url 'mfa:auth' method %}">use {{method}} instead</a>
+    {% endif %}
+    {% endfor %}.
 </p>
+{% endblock %}
 
+{% block form %}
 <form method="POST">
     {% csrf_token %}
-    {% for error in form.non_field_errors %}
-        <p>{{ error }}</p>
-    {% endfor %}
-    <label>
-        {{ form.code.label }}
-        {{ form.code }}
-    </label>
-    <button>Verify</button>
-    <a href="{% url 'mfa:auth' 'FIDO2' %}">Use FIDO2 instead</a>
-    <a href="{% url 'mfa:auth' 'TOTP' %}">Use TOTP instead</a>
+    <div class="form-row">
+        {{ form.code.errors }}
+        <h2>{{ form.code.label }}:</h2>
+        <p>{{ form.code }}</p>
+    </div>
+    <div class="submit-row">
+        <input type="submit" value="{% translate 'Verify' %}">
+        <input type="hidden" name="next" value="{{ next }}">
+    </div>
 </form>
+{% endblock %}

--- a/mfa/templates/mfa/base.html
+++ b/mfa/templates/mfa/base.html
@@ -1,0 +1,41 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static 'admin/css/login.css' %}">
+{{ form.media }}
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} login mfa{% endblock %}
+
+{% block usertools %}{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block nav-sidebar %}{% endblock %}
+
+{% block content_title %}{% endblock %}
+
+{% block nav-breadcrumbs %}{% endblock %}
+
+{% block content %}
+{% if form.errors and not form.non_field_errors %}
+<p class="errornote">
+{% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+</p>
+{% endif %}
+
+{% if form.non_field_errors %}
+{% for error in form.non_field_errors %}
+<p class="errornote">
+    {{ error }}
+</p>
+{% endfor %}
+{% endif %}
+
+<div id="content-main">
+
+{% block form %}
+{% endblock %}
+
+</div>
+{% endblock %}

--- a/mfa/templates/mfa/create_FIDO2.html
+++ b/mfa/templates/mfa/create_FIDO2.html
@@ -1,19 +1,27 @@
+{% extends "mfa/base.html" %}
+{% load i18n static %}
+
+{% block content_subtitle %}
+<p>
+    You will be prompted to activate the device once you click "create".
+</p>
+{% endblock %}
+
+{% block form %}
 {% load static %}
-
-<p>You will be prompted to activate the device once you click "create".</p>
-
-<form data-fido2-create="{{ mfa_data }}" method="POST">
-    {% csrf_token %}
-    {% for error in form.non_field_errors %}
-        <p>{{ error }}</p>
-    {% endfor %}
-    <label>
-        {{ form.name.label }}
-        {{ form.name }}
-    </label>
-    {{ form.code.as_hidden }}
-    <button>Create</button>
-</form>
-
 <script src="{% static 'cbor-js/cbor.js' %}"></script>
 <script src="{% static 'mfa/fido2.js' %}"></script>
+<form data-fido2-create="{{ mfa_data }}" method="POST">
+    {% csrf_token %}
+    <div class="form-row">
+        {{ form.name.errors }}
+        {{ form.name.label }}
+        {{ form.name }}
+    </div>
+    {{ form.code.as_hidden }}
+    <div class="submit-row">
+        <input type="submit" value="{% translate 'Create' %}">
+        <input type="hidden" name="next" value="{{ next }}">
+    </div>
+</form>
+{% endblock %}

--- a/mfa/templates/mfa/create_TOTP.html
+++ b/mfa/templates/mfa/create_TOTP.html
@@ -1,22 +1,33 @@
+{% extends "mfa/base.html" %}
+{% load i18n static %}
+
+{% block content_subtitle %}
+<p>
+    Scan the code with your TOTP app and enter a valid code to finish registration.
+</p>
+{% endblock %}
+
+{% block form %}
 {% load static mfa %}
-
-<p>Scan the code with your TOTP app and enter a valid code to finish registration.</p>
-
-{{ mfa_data.url|qrcode }}
-{{ mfa_data.secret }}
-
+<div style="margin-bottom: 10px;">
+    <div style="color: black; background-color: white; width: min-content; margin: auto;">{{ mfa_data.url|qrcode }}</div>
+    <div style="width: min-content; margin: 12px auto;">{{ mfa_data.secret }}</div>
+</div>
 <form method="POST">
     {% csrf_token %}
-    {% for error in form.non_field_errors %}
-        <p>{{ error }}</p>
-    {% endfor %}
-    <label>
-        {{ form.name.label }}
-        {{ form.name }}
-    </label>
-    <label>
-        {{ form.code.label }}
-        {{ form.code }}
-    </label>
-    <button>Create</button>
+    <div class="form-row">
+        {{ form.name.errors }}
+        {{ form.name.label }} {{ form.name }}
+    </div>
+    <div class="form-row">
+        {{ form.code.errors }}
+        {{ form.code.label }} {{ form.code }}
+        </div>
+    <div class="submit-row">
+        <input type="submit" value="{% translate 'Create' %}">
+        <input type="hidden" name="next" value="{{ next }}">
+    </div>
 </form>
+
+</div>
+{% endblock %}

--- a/mfa/templates/mfa/create_recovery.html
+++ b/mfa/templates/mfa/create_recovery.html
@@ -1,24 +1,38 @@
+{% extends "mfa/base.html" %}
+{% load i18n static %}
+
+{% block content_subtitle %}
+<p>
+    A recovery code can be used when you lose access to your other two-factor
+    authentication options. Each recovery code can only be used once.
+</p>
+<p>
+    Make sure to store it in a safe place! If you lose your login keys and don't
+    have the recovery codes you will lose access to your account.
+</p>
+{% endblock %}
+
+{% block form %}
 {% load static mfa %}
-
-<p>A recovery code can be used when you lose access to your other two-factor authentication options. Each recovery code can only be used once.</p>
-<p>Make sure to store it in a safe place! If you lose your login keys and don’t have the recovery codes you will lose access to your account.</p>
-
 <form method="POST">
     {% csrf_token %}
-    {% for error in form.non_field_errors %}
-        <p>{{ error }}</p>
-    {% endfor %}
-    <label>
+    <div class="form-row">
+        {{ form.name.errors }}
         {{ form.name.label }}
         {{ form.name }}
-    </label>
-    <label>
+    </div>
+    <div class="form-row">
+        {{ form.code.errors }}
         {{ form.code.label }}
         <input name="code" value="{{ mfa_data.code }}" readonly>
-    </label>
-    <label>
+    </div>
+    <div class="form-row">
         <input type="checkbox" required>
         I have safely stored the code
-    </label>
-    <button>Create</button>
+    </div>
+    <div class="submit-row">
+        <input type="submit" value="{% translate 'Create' %}">
+        <input type="hidden" name="next" value="{{ next }}">
+    </div>
 </form>
+{% endblock %}

--- a/mfa/templates/mfa/mfakey_confirm_delete.html
+++ b/mfa/templates/mfa/mfakey_confirm_delete.html
@@ -1,5 +1,18 @@
-<p>Are you sure you want to delete the key {{ object.name }}?</p>
+{% extends "mfa/base.html" %}
+{% load i18n static %}
+
+{% block content_subtitle %}
+<p>
+    Are you sure you want to delete the key {{ object.name }}?
+</p>
+{% endblock %}
+
+{% block form %}
 <form method="POST">
     {% csrf_token %}
-    <button>Confirm</button>
+    <div class="submit-row">
+        <input type="submit" value="{% translate 'Confirm' %}">
+        <input type="hidden" name="next" value="{{ next }}">
+    </div>
 </form>
+{% endblock %}

--- a/mfa/templates/mfa/mfakey_list.html
+++ b/mfa/templates/mfa/mfakey_list.html
@@ -1,23 +1,44 @@
-<h1> {% if object_list %}Login keys configured{% else %}No login keys configured{% endif %}</h1>
-<p>Two-factor authentication adds an additional layer of security to your account by requiring more than just a password to log in.</p>
+{% extends "mfa/base.html" %}
+{% load i18n static %}
 
+{% block content_title %}
+<h1>{% if object_list %}Login keys configured{% else %}No login keys configured{% endif %}</h1>
+{% endblock %}
+
+{% block content_subtitle %}
+<p>
+    Two-factor authentication adds an additional layer of security to your account
+    by requiring more than just a password to log in.
+</p>
+<p>
+    This can be done with apps like google authenticator or microsoft authenticator.
+</p>
 {% if object_list|length == 1 %}
-    <p>
-        <strong>WARNING</strong>:
-        You have registered only a single key. If you lose access to that key you won't be able log into your account again.
-        <a href="{% url 'mfa:create' 'recovery' %}">Create recovery code</a>
-    </p>
+<p>
+    <strong>WARNING</strong>:
+    You have registered only a single key. If you lose access to that key you
+    won't be able log into your account again.
+</p>
 {% endif %}
-
 <ul>
-    {% for key in object_list %}
-        <li>
-            {{ key.name }} ({{ key.method }})
-            <a href="{% url 'mfa:delete' key.id %}">Delete</a>
-        </li>
-    {% endfor %}
+{% for key in object_list %}
+    <li>
+        {{ key.name }} ({{ key.method }})
+        <a href="{% url 'mfa:delete' key.id %}">Delete</a>
+    </li>
+{% endfor %}
 </ul>
+{% endblock %}
 
-<a href="{% url 'mfa:create' 'TOTP' %}">Create TOTP key</a>
-<a href="{% url 'mfa:create' 'FIDO2' %}">Create FIDO2 key</a>
-<a href="{% url 'mfa:create' 'recovery' %}">Create recovery code</a>
+{% block form %}
+<h1>
+    {% if methods|length == 1 %}C{% else %}Select a type to c{% endif %}reate a key:
+</h1>
+<div style="text-align: center;">
+{% for method in methods %}
+    <a class="button" href="{% url 'mfa:create' method %}" style="padding: 5px 10px; margin: 2px;">
+    {{ method }}
+    </a>
+{% endfor %}
+</div>
+{% endblock %}

--- a/mfa/views.py
+++ b/mfa/views.py
@@ -49,6 +49,11 @@ class MFAListView(LoginRequiredMixin, ListView):
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)
 
+    def get_context_data(self, **kwargs: settings.DOMAIN):
+        context = super().get_context_data(**kwargs)
+        context['methods'] = settings.METHODS
+        return context
+
 
 class MFADeleteView(LoginRequiredMixin, DeleteView):
     model = MFAKey
@@ -100,6 +105,11 @@ class MFAAuthView(MFAFormView):
             return reverse('mfa:list')
         else:
             return success_url
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['methods'] = settings.METHODS
+        return context
 
     @cached_property
     def user(self):


### PR DESCRIPTION
With this change the templates look the same as the admin login interface with no extra templates.

You can set the root `url.py` like this
```python
from mfa.views import LoginView

urlpatterns = [
    path(
        "admin/login/",
        LoginView.as_view(template_name="admin/login.html"),
        name="login",
    ),
...
```