### PR TITLE
add setting MAX_KEYS_PER_ACCOUNT

### DIFF
--- a/mfa/settings.py
+++ b/mfa/settings.py
@@ -17,3 +17,12 @@ TOTP_VALID_WINDOW = getattr(settings, 'MFA_TOTP_VALID_WINDOW', 0)
 # `user_verification` parameter passed to python-fido2
 # See https://www.w3.org/TR/webauthn/#enum-userVerificationRequirement
 FIDO2_USER_VERIFICATION = getattr(settings, 'MFA_FIDO2_USER_VERIFICATION', None)
+
+# An account might end up having a large number of keys
+# if it is shared by multiple users or if lost keys are not
+# deleted. Both are potential security issues, so this is
+# restricted to a reasonable (but small) number by default.
+#
+# This setting only applies when adding new keys.
+# To allow an arbitrary number of keys, set this to `None`.
+MAX_KEYS_PER_ACCOUNT = getattr(settings, 'MFA_MAX_KEYS_PER_ACCOUNT', 3)

--- a/mfa/templates/mfa/mfakey_list.html
+++ b/mfa/templates/mfa/mfakey_list.html
@@ -18,6 +18,13 @@
     {% endfor %}
 </ul>
 
-<a href="{% url 'mfa:create' 'TOTP' %}">Create TOTP key</a>
-<a href="{% url 'mfa:create' 'FIDO2' %}">Create FIDO2 key</a>
-<a href="{% url 'mfa:create' 'recovery' %}">Create recovery code</a>
+{% if max_keys and user.mfakey_set.count >= max_keys %}
+    <p>
+        You cannot have more than {{ max_keys }} keys.
+        Please delete one of your existing keys before adding a new one.
+    </p>
+{% else %}
+    <a href="{% url 'mfa:create' 'TOTP' %}">Create TOTP key</a>
+    <a href="{% url 'mfa:create' 'FIDO2' %}">Create FIDO2 key</a>
+    <a href="{% url 'mfa:create' 'recovery' %}">Create recovery code</a>
+{% endif %}


### PR DESCRIPTION
An account might end up having a large number of keys if it is shared by multiple users or if lost keys are not deleted. Both are potential security issues, so this should be restricted to a reasonable (but small) number by default.